### PR TITLE
chore: update Go version to 1.24.3 in Dockerfile and go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24.1-alpine AS builder
+FROM golang:1.24.3-alpine AS builder
 
 # Install required dependencies (GCC + WebP)
 RUN apk add --no-cache gcc musl-dev libwebp-dev

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module greenvue
 
-go 1.24.1
+go 1.24.3
 
 require (
 	github.com/go-resty/resty/v2 v2.16.5


### PR DESCRIPTION
This pull request updates the Go version used in the project to the latest patch version for improved stability and security. The changes affect both the `Dockerfile` and the `go.mod` file.

Version update:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2): Updated the base image from `golang:1.24.1-alpine` to `golang:1.24.3-alpine`.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.24.1` to `1.24.3`.